### PR TITLE
feat: Support kebabcase cmd args and snakecase env vars at the same time.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,6 @@
-//Package goconfig uses a struct as input and populates the
-//fields of this struct with parameters fom command
-//line, environment variables and configuration file.
+// Package goconfig uses a struct as input and populates the
+// fields of this struct with parameters fom command
+// line, environment variables and configuration file.
 package goconfig
 
 import (
@@ -12,11 +12,11 @@ import (
 
 	"path/filepath"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/h2oai/goconfig/goenv"
 	"github.com/h2oai/goconfig/goflags"
 	"github.com/h2oai/goconfig/structtag"
 	"github.com/h2oai/goconfig/validate"
-	"github.com/fsnotify/fsnotify"
 )
 
 // Fileformat struct holds the functions to Load the file containing the settings
@@ -75,6 +75,9 @@ var (
 
 	// DisableFlags on the command line
 	DisableFlags bool
+
+	// Convert kebabcase (dashes) cmd args to snakecase (underscores) environment variables
+	KebabCfgToSnakeEnv bool
 )
 
 func findFileFormat(extension string) (format Fileformat, err error) {
@@ -104,7 +107,7 @@ func init() {
 // Parse configuration
 func Parse(config interface{}) (err error) {
 	goenv.Prefix = PrefixEnv
-	goenv.Setup(Tag, TagDefault)
+	goenv.Setup(Tag, TagDefault, KebabCfgToSnakeEnv)
 	err = structtag.SetBoolDefaults(config, "")
 	if err != nil {
 		return
@@ -120,7 +123,7 @@ func Parse(config interface{}) (err error) {
 	}
 
 	goenv.Prefix = PrefixEnv
-	goenv.Setup(Tag, TagDefault)
+	goenv.Setup(Tag, TagDefault, KebabCfgToSnakeEnv)
 	err = goenv.Parse(config)
 	if err != nil {
 		return

--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -23,13 +23,14 @@ var (
 )
 
 // Setup maps and variables
-func Setup(tag string, tagDefault string) {
+func Setup(tag string, tagDefault string, kebabCfgToSnakeEnv bool) {
 	Usage = DefaultUsage
 
 	structtag.Setup()
 	structtag.Prefix = Prefix
 	SetTag(tag)
 	SetTagDefault(tagDefault)
+	SetKebabCfgToSnakeEnv(kebabCfgToSnakeEnv)
 
 	structtag.ParseMap[reflect.Int64] = reflectInt
 	structtag.ParseMap[reflect.Int] = reflectInt
@@ -45,9 +46,14 @@ func SetTag(tag string) {
 	structtag.Tag = tag
 }
 
-// SetTagDefault set a new TagDefault to retorn default values
+// SetTagDefault set a new TagDefault to return default values
 func SetTagDefault(tag string) {
 	structtag.TagDefault = tag
+}
+
+// SetKebabCfgToSnakeEnv set a new CfgToSnakeEnv to look for snakecase environment variables
+func SetKebabCfgToSnakeEnv(cfgToSnakeEnv bool) {
+	structtag.KebabCfgToSnakeEnv = cfgToSnakeEnv
 }
 
 // Parse configuration
@@ -77,8 +83,11 @@ func parseValue(datatype string, value *reflect.Value) (ret string, ok bool) {
 func getNewValue(field *reflect.StructField, value *reflect.Value, tag string, datatype string) (ret string) {
 	defaultValue := field.Tag.Get(structtag.TagDefault)
 
-	// create PrintDefaults output
 	tag = strings.ToUpper(tag)
+	if structtag.KebabCfgToSnakeEnv {
+		tag = strings.Replace(tag, "-", "_", -1)
+	}
+
 	sysvar := `$` + tag
 	if runtime.GOOS == "windows" {
 		sysvar = `%` + tag + `%`

--- a/structtag/structtag.go
+++ b/structtag/structtag.go
@@ -1,8 +1,8 @@
 package structtag
 
 import (
-	"fmt"
 	"errors"
+	"fmt"
 	"reflect"
 )
 
@@ -45,6 +45,9 @@ var (
 
 	// ParseMap points to each of the supported types
 	ParseMap map[reflect.Kind]ReflectFunc
+
+	// Convert kebabcase (dashes) cmd args to snakecase (underscores) environment variables
+	KebabCfgToSnakeEnv bool
 )
 
 // Setup maps and variables
@@ -64,7 +67,7 @@ func Reset() {
 	Setup()
 }
 
-//Parse tags on struct instance
+// Parse tags on struct instance
 func Parse(s interface{}, superTag string) (err error) {
 	if Tag == "" {
 		err = ErrUndefinedTag


### PR DESCRIPTION
Naming is hard.

This PR allows using kebabcase (dash separator) in cmd args while still working with snakecase env variables. Env variables do not support dashes. This is needed to be used in Wave which accepts configuration cmd args e.g. `web-dir` and  the corresponding env var `WEB_DIR`.

A feature flag was added to avoid introducing a breaking change.