### PR TITLE
feat: Allow ignoring supertags (parent struct names) in cfg names.

### DIFF
--- a/config.go
+++ b/config.go
@@ -78,6 +78,9 @@ var (
 
 	// Convert kebabcase (dashes) cmd args to snakecase (underscores) environment variables
 	KebabCfgToSnakeEnv bool
+
+	// Do not prefix tag with parent struct name
+	IgnoreSuperTag bool
 )
 
 func findFileFormat(extension string) (format Fileformat, err error) {
@@ -107,7 +110,7 @@ func init() {
 // Parse configuration
 func Parse(config interface{}) (err error) {
 	goenv.Prefix = PrefixEnv
-	goenv.Setup(Tag, TagDefault, KebabCfgToSnakeEnv)
+	goenv.Setup(Tag, TagDefault, KebabCfgToSnakeEnv, IgnoreSuperTag)
 	err = structtag.SetBoolDefaults(config, "")
 	if err != nil {
 		return
@@ -123,7 +126,7 @@ func Parse(config interface{}) (err error) {
 	}
 
 	goenv.Prefix = PrefixEnv
-	goenv.Setup(Tag, TagDefault, KebabCfgToSnakeEnv)
+	goenv.Setup(Tag, TagDefault, KebabCfgToSnakeEnv, IgnoreSuperTag)
 	err = goenv.Parse(config)
 	if err != nil {
 		return

--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -23,7 +23,7 @@ var (
 )
 
 // Setup maps and variables
-func Setup(tag string, tagDefault string, kebabCfgToSnakeEnv bool) {
+func Setup(tag, tagDefault string, kebabCfgToSnakeEnv, ignoreSuperTag bool) {
 	Usage = DefaultUsage
 
 	structtag.Setup()
@@ -31,6 +31,7 @@ func Setup(tag string, tagDefault string, kebabCfgToSnakeEnv bool) {
 	SetTag(tag)
 	SetTagDefault(tagDefault)
 	SetKebabCfgToSnakeEnv(kebabCfgToSnakeEnv)
+	SetIgnoreSuperTag(ignoreSuperTag)
 
 	structtag.ParseMap[reflect.Int64] = reflectInt
 	structtag.ParseMap[reflect.Int] = reflectInt
@@ -54,6 +55,10 @@ func SetTagDefault(tag string) {
 // SetKebabCfgToSnakeEnv set a new CfgToSnakeEnv to look for snakecase environment variables
 func SetKebabCfgToSnakeEnv(cfgToSnakeEnv bool) {
 	structtag.KebabCfgToSnakeEnv = cfgToSnakeEnv
+}
+
+func SetIgnoreSuperTag(ignoreSuperTag bool) {
+	structtag.IgnoreSuperTag = ignoreSuperTag
 }
 
 // Parse configuration

--- a/goenv/goenv_test.go
+++ b/goenv/goenv_test.go
@@ -36,7 +36,7 @@ type testSubSub struct {
 func TestParse(t *testing.T) {
 
 	Prefix = "PREFIX"
-	Setup("cfg", "cfgDefault")
+	Setup("cfg", "cfgDefault", false, false)
 
 	os.Setenv("PREFIX_A", "900")
 	os.Setenv("PREFIX_B", "TEST")

--- a/structtag/structtag.go
+++ b/structtag/structtag.go
@@ -48,6 +48,9 @@ var (
 
 	// Convert kebabcase (dashes) cmd args to snakecase (underscores) environment variables
 	KebabCfgToSnakeEnv bool
+
+	// Do not prefix tag with parent struct name
+	IgnoreSuperTag bool
 )
 
 // Setup maps and variables
@@ -176,7 +179,7 @@ func updateTag(field *reflect.StructField, superTag string) (ret string) {
 	if ret == "" {
 		ret = field.Name
 	}
-	if superTag != "" {
+	if !IgnoreSuperTag && superTag != "" {
 		ret = superTag + TagSeparator + ret
 		return
 	}


### PR DESCRIPTION
This PR allows for ignoring parent struct names in configuration options. This means that

```go
type systemUser struct {
	Name     string `json:"name" cfg:"name"`
	Password string `json:"passwd" cfg:"passwd"`
}

type configTest struct {
	Domain string
	User   systemUser
}
```

Would register flags `-user_name` and `-user_passwd`. With the newly added flag, this would be more flat `-name` and `-passwd`.

Added feature flag to avoid introducing a breaking change.