### PR TITLE
feat: Add explicit env tag for .env plugin.

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -44,11 +44,7 @@ func LoadEnv(config interface{}) error {
 			continue
 		}
 
-		prefix := ""
-		if goconfig.PrefixEnv != "" {
-			prefix = goconfig.PrefixEnv + "_"
-		}
-		value, ok := dotEnvMap[prefix+confKey]
+		value, ok := dotEnvMap[confKey]
 		if !ok {
 			continue
 		}

--- a/env/env.go
+++ b/env/env.go
@@ -94,12 +94,12 @@ func PrepareHelp(config interface{}) (string, error) {
 }
 
 func getConfKey(field reflect.StructField) string {
-	confKey := field.Tag.Get("env")
-	if confKey == "" {
-		confKey = field.Tag.Get("cfg")
+	k := field.Tag.Get("env")
+	if k == "" {
+		k = field.Tag.Get("cfg")
 	}
-	if confKey == "" {
-		confKey = strings.ToUpper(field.Name)
+	if k == "" {
+		k = strings.ToUpper(field.Name)
 	}
-	return confKey
+	return k
 }

--- a/env/env.go
+++ b/env/env.go
@@ -33,25 +33,28 @@ func LoadEnv(config interface{}) error {
 		return err
 	}
 
-	// Format .env file keys.
-	for k, v := range dotEnvMap {
-		delete(dotEnvMap, k)
-		if strings.HasPrefix(k, goconfig.PrefixEnv) {
-			k = strings.TrimPrefix(k, goconfig.PrefixEnv+"_")
-		}
-		dotEnvMap[strings.ToLower(k)] = v
-	}
-
 	configType := reflect.TypeOf(config).Elem()
 	configValue := reflect.ValueOf(config).Elem()
 
 	for i := 0; i < configType.NumField(); i++ {
 		field := configType.Field(i)
-		tag := field.Tag.Get("cfg")
-		if tag == "" {
+
+		confKey := field.Tag.Get("env")
+		if confKey == "" {
+			confKey = field.Tag.Get("cfg")
+		}
+		if confKey == "-" {
 			continue
 		}
-		value, ok := dotEnvMap[tag]
+		if confKey == "" {
+			confKey = strings.ToUpper(field.Name)
+		}
+
+		prefix := ""
+		if goconfig.PrefixEnv != "" {
+			prefix = goconfig.PrefixEnv + "_"
+		}
+		value, ok := dotEnvMap[prefix+confKey]
 		if !ok {
 			continue
 		}
@@ -70,12 +73,6 @@ func LoadEnv(config interface{}) error {
 				return fmt.Errorf("failed to parse bool value for field %s: %v", field.Name, err)
 			}
 			configValue.Field(i).SetBool(boolValue)
-		case reflect.Slice:
-			if field.Type.Elem().Kind() == reflect.String {
-				configValue.Field(i).Set(reflect.ValueOf(strings.Split(value, " ")))
-				break
-			}
-			return fmt.Errorf("unsupported slice element type: %v", field.Type.Elem().Kind())
 		default:
 			return fmt.Errorf("unsupported field type: %v", field.Type.Kind())
 		}
@@ -88,20 +85,24 @@ func PrepareHelp(config interface{}) (string, error) {
 	var helpAux []byte
 	configValue := reflect.ValueOf(config).Elem()
 	for i := 0; i < configValue.NumField(); i++ {
-		fieldName := configValue.Type().Field(i).Name
-		var snakeCase []byte
-		for i, c := range fieldName {
-			if i > 0 && c >= 'A' && c <= 'Z' {
-				snakeCase = append(snakeCase, '_')
-			}
-			snakeCase = append(snakeCase, byte(c))
+		fieldType := configValue.Type().Field(i)
+
+		confKey := fieldType.Tag.Get("env")
+		if confKey == "" {
+			confKey = fieldType.Tag.Get("cfg")
 		}
+		if confKey == "-" {
+			continue
+		}
+		if confKey == "" {
+			confKey = strings.ToUpper(fieldType.Name)
+		}
+
 		prefix := ""
 		if goconfig.PrefixEnv != "" {
 			prefix = goconfig.PrefixEnv + "_"
 		}
-		helpAux = append(helpAux, []byte(prefix+strings.ToUpper(string(snakeCase)))...)
-		helpAux = append(helpAux, []byte("=value\n")...)
+		helpAux = append(helpAux, []byte(prefix+strings.ToUpper(confKey)+"=value\n")...)
 	}
 	return string(helpAux), nil
 }

--- a/env/env.go
+++ b/env/env.go
@@ -88,7 +88,8 @@ func PrepareHelp(config interface{}) (string, error) {
 		if goconfig.PrefixEnv != "" {
 			prefix = goconfig.PrefixEnv + "_"
 		}
-		helpAux = append(helpAux, []byte(prefix+strings.ToUpper(confKey)+"=value\n")...)
+		helpLine := fmt.Sprintf("%s%s=value\n", prefix, strings.ToUpper(confKey))
+		helpAux = append(helpAux, []byte(helpLine)...)
 	}
 	return string(helpAux), nil
 }

--- a/env/env.go
+++ b/env/env.go
@@ -80,8 +80,7 @@ func PrepareHelp(config interface{}) (string, error) {
 			continue
 		}
 
-		helpLine := fmt.Sprintf("%s=value\n", strings.ToUpper(confKey))
-		helpAux = append(helpAux, []byte(helpLine)...)
+		helpAux = append(helpAux, []byte(strings.ToUpper(confKey)+"=value\n")...)
 	}
 	return string(helpAux), nil
 }

--- a/env/env.go
+++ b/env/env.go
@@ -39,15 +39,9 @@ func LoadEnv(config interface{}) error {
 	for i := 0; i < configType.NumField(); i++ {
 		field := configType.Field(i)
 
-		confKey := field.Tag.Get("env")
-		if confKey == "" {
-			confKey = field.Tag.Get("cfg")
-		}
+		confKey := getConfKey(field)
 		if confKey == "-" {
 			continue
-		}
-		if confKey == "" {
-			confKey = strings.ToUpper(field.Name)
 		}
 
 		prefix := ""
@@ -85,17 +79,9 @@ func PrepareHelp(config interface{}) (string, error) {
 	var helpAux []byte
 	configValue := reflect.ValueOf(config).Elem()
 	for i := 0; i < configValue.NumField(); i++ {
-		fieldType := configValue.Type().Field(i)
-
-		confKey := fieldType.Tag.Get("env")
-		if confKey == "" {
-			confKey = fieldType.Tag.Get("cfg")
-		}
+		confKey := getConfKey(configValue.Type().Field(i))
 		if confKey == "-" {
 			continue
-		}
-		if confKey == "" {
-			confKey = strings.ToUpper(fieldType.Name)
 		}
 
 		prefix := ""
@@ -105,4 +91,18 @@ func PrepareHelp(config interface{}) (string, error) {
 		helpAux = append(helpAux, []byte(prefix+strings.ToUpper(confKey)+"=value\n")...)
 	}
 	return string(helpAux), nil
+}
+
+func getConfKey(field reflect.StructField) string {
+	confKey := field.Tag.Get("env")
+	if confKey == "" {
+		confKey = field.Tag.Get("cfg")
+	}
+	if confKey == "-" {
+		return "-"
+	}
+	if confKey == "" {
+		confKey = strings.ToUpper(field.Name)
+	}
+	return confKey
 }

--- a/env/env.go
+++ b/env/env.go
@@ -98,9 +98,6 @@ func getConfKey(field reflect.StructField) string {
 	if confKey == "" {
 		confKey = field.Tag.Get("cfg")
 	}
-	if confKey == "-" {
-		return "-"
-	}
 	if confKey == "" {
 		confKey = strings.ToUpper(field.Name)
 	}

--- a/env/env.go
+++ b/env/env.go
@@ -80,11 +80,7 @@ func PrepareHelp(config interface{}) (string, error) {
 			continue
 		}
 
-		prefix := ""
-		if goconfig.PrefixEnv != "" {
-			prefix = goconfig.PrefixEnv + "_"
-		}
-		helpLine := fmt.Sprintf("%s%s=value\n", prefix, strings.ToUpper(confKey))
+		helpLine := fmt.Sprintf("%s=value\n", strings.ToUpper(confKey))
 		helpAux = append(helpAux, []byte(helpLine)...)
 	}
 	return string(helpAux), nil

--- a/examples/env_config_file/main.go
+++ b/examples/env_config_file/main.go
@@ -8,11 +8,11 @@ import (
 )
 
 type Config struct {
-	Host     string   `cfg:"db_host" cfgDefault:"default.host"`
-	Port     int      `cfg:"db_port" cfgDefault:"10101"`
-	Enabled  bool     `cfg:"db_enabled"`
-	ReadOnly bool     `cfg:"db_readonly"`
-	Options  []string `cfg:"db_options"`
+	Host     string `cfg:"db_host" env:"DB_HOST" cfgDefault:"default.host"`
+	Port     int    `cfg:"db_port" env:"DB_PORT" cfgDefault:"10101"`
+	Enabled  bool   `cfg:"db_enabled" env:"DB_ENABLED"`
+	ReadOnly bool   `cfg:"db_readonly" env:"DB_READONLY"`
+	Options  string `cfg:"db_options" env:"DB_OPTIONS"`
 }
 
 func main() {


### PR DESCRIPTION
Adds a new `env` tag to explicitly define .env file value names, consistent with other supported formats like `yaml` or `json`.

Tag priority: `env` > `cfg` > `fieldName`. FieldName is only used if not explicitly ignored via `-`.