### PR TITLE
feat: Make boolean conf options case-insensitive + allow numericals.

### DIFF
--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -157,7 +157,8 @@ func reflectBool(field *reflect.StructField, value *reflect.Value, tag string) (
 	if newValue == "" {
 		return
 	}
-	newBoolValue := newValue == "true" || newValue == "t"
+	newValue = strings.ToLower(newValue)
+	newBoolValue := newValue == "true" || newValue == "t" || newValue == "1"
 	value.SetBool(newBoolValue)
 	return
 }

--- a/goflags/goflags.go
+++ b/goflags/goflags.go
@@ -194,7 +194,8 @@ func reflectString(field *reflect.StructField, value *reflect.Value, tag string)
 func reflectBool(field *reflect.StructField, value *reflect.Value, tag string) (err error) {
 	var aux bool
 	defaltTag := field.Tag.Get(structtag.TagDefault)
-	defaltValue := defaltTag == "true" || defaltTag == "t"
+	defaltTag = strings.ToLower(defaltTag)
+	newValue := defaltTag == "true" || defaltTag == "t" || defaltTag == "1"
 	usage := field.Tag.Get(structtag.TagHelper)
 
 	meta := parameterMeta{}
@@ -203,7 +204,7 @@ func reflectBool(field *reflect.StructField, value *reflect.Value, tag string) (
 	meta.Kind = reflect.Bool
 	parametersMetaMap[value] = meta
 
-	flag.BoolVar(&aux, meta.Tag, defaltValue, usage)
+	flag.BoolVar(&aux, meta.Tag, newValue, usage)
 
 	return
 }


### PR DESCRIPTION
This PR introduces case-insensitiveness and numerical values for boolean config options. Needed for https://github.com/h2oai/wave.

@geomodular @michal-raska This can be technically a breaking change so let me know if you think it makes sense as a separate goconfig configuration option instead of hardcoding.